### PR TITLE
RSDEV-444: Upgrade argos-java-client to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.0.0]
+- Spring 6 / Hibernate 6 / Jakarta migration (RSDEV-444)
+- Upgrade to rspace-parent 3.0.0
+
 ## [0.1.1]
 - switch parent pom from rspace-os-parent to rspace-parent (updates/changes a lot of dependencies)
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>argos-java-client</artifactId>
-    <version>0.1.1</version>
+    <version>1.0.0</version>
 
     <parent>
         <groupId>com.github.rspace-os</groupId>
         <artifactId>rspace-parent</artifactId>
-        <version>2.1.4</version>
+        <version>3.0.0</version>
     </parent>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.github.rspace-os</groupId>
         <artifactId>rspace-parent</artifactId>
-        <version>3.0.0</version>
+        <version>rsdev-444-upgrade-to-spring-6-SNAPSHOT</version>
     </parent>
 
     <repositories>


### PR DESCRIPTION
Upgrade argos-java-client to 1.0.0 for Spring 6 / Jakarta migration (RSDEV-444).

Pom-only parent bump; no source changes required.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>